### PR TITLE
Fix typescript types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.7",
   "description": "Capture and inspect heap snapshots from Puppeteer",
   "main": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "author": "Adrian Cooney <cooney.adrian@gmail.com>",
   "license": "MIT",
   "bin": "./dist/cjs/bin/puppeteer-heap-snapshot.js",


### PR DESCRIPTION
It seems that types are generated inside the `src` folder. We had to manually change them in order to make tsc happy.