### PR TITLE
feat: add options to set depth and to skip unwanted node names

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepack": "npm run build",
     "prepare": "husky install && npm run lint && npm run test",
-    "format": "prettier --write '**/*.ts' '!dist/**/*'",
+    "format": "prettier --write \"**/*.ts\" \"!dist/**/*\"",
     "lint": "eslint . --ext .ts",
     "test": "jest",
     "build:esm": "tsc --project tsconfig.esm.json",

--- a/src/query.ts
+++ b/src/query.ts
@@ -5,6 +5,8 @@ import { buildObjectFromNodeId } from "./build-object";
 
 type FindObjectOptions = {
   ignoreProperties?: readonly string[];
+  maxDepth?: number;
+  unwantedNodeNames?: readonly string[];
 };
 
 type FindObjectReturnValue<
@@ -34,16 +36,17 @@ export function findObjectsWithProperties<
     );
   }
 
-  return nodeIds.map((nodeId) => {
-    debug(`node ${nodeId} found`);
-    return buildObjectFromNodeId(
-      heapSnapshot,
-      nodeId,
-      options?.ignoreProperties
-        ? (prop) => !options.ignoreProperties!.includes(prop)
-        : undefined
-    );
-  }) as FindObjectReturnValue<Props, Options>[];
+  return nodeIds
+    .map((nodeId) => {
+      debug(`node ${nodeId} found`);
+      return buildObjectFromNodeId(heapSnapshot, nodeId, {
+        ...options,
+        propertyFilter: options?.ignoreProperties
+          ? (prop) => !options.ignoreProperties!.includes(prop)
+          : undefined,
+      });
+    })
+    .filter((v) => v !== undefined) as FindObjectReturnValue<Props, Options>[];
 }
 
 export function findObjectWithProperties<

--- a/src/structured-graph.ts
+++ b/src/structured-graph.ts
@@ -15,6 +15,7 @@ import {
 export function createStructuredGraph(
   heapSnapshot: HeapSnapshot,
   nodeId: number,
+  structuredNode: HeapSnapshotStructuredNode,
   {
     maxDepth = Infinity,
     edgeFilter = () => true,
@@ -24,7 +25,6 @@ export function createStructuredGraph(
   } = {},
   nodeIdStack: number[] = []
 ): HeapSnapshotStructuredGraph {
-  const structuredNode = createStructuredNode(heapSnapshot, nodeId);
   const structuredEdges = structuredNode.edgeIds
     .map((edgeId) => createStructuredEdge(heapSnapshot, edgeId))
     .filter(edgeFilter);
@@ -42,6 +42,7 @@ export function createStructuredGraph(
             ? createStructuredGraph(
                 heapSnapshot,
                 structuredEdge.nodeId,
+                createStructuredNode(heapSnapshot, structuredEdge.nodeId),
                 { maxDepth, edgeFilter },
                 [...nodeIdStack, nodeId]
               )
@@ -51,7 +52,7 @@ export function createStructuredGraph(
   };
 }
 
-function createStructuredNode(
+export function createStructuredNode(
   heapSnapshot: HeapSnapshot,
   nodeId: number
 ): HeapSnapshotStructuredNode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export type HeapSnapshot = Omit<SerializedHeapSnapshot, "nodes" | "edges"> & {
 
 export type BuiltHeapValue =
   | undefined
+  | null
   | string
   | number
   | RegExp

--- a/tests/__snapshots__/query.test.ts.snap
+++ b/tests/__snapshots__/query.test.ts.snap
@@ -1,0 +1,403 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`query findObjectsWithProperties finds some objects respecting unwantedNodeNames and maxDepth options 1`] = `
+Array [
+  Object {
+    "children": "disclaimer",
+    "href": "/disclaimer/",
+  },
+  Object {
+    "children": "privacy policy",
+    "href": "/privacy/",
+  },
+  Object {
+    "hash": "",
+    "host": "polypane.app",
+    "hostname": "polypane.app",
+    "href": "https://polypane.app/css-specificity-calculator/",
+    "key": "initial",
+    "origin": "https://polypane.app",
+    "pathname": "/css-specificity-calculator/",
+    "port": "",
+    "protocol": "https:",
+    "search": "",
+  },
+  Object {
+    "children": "disclaimer",
+    "href": "/disclaimer/",
+  },
+  Object {
+    "children": Array [],
+    "className": "Header-styles-module--logo--1JkU1",
+    "href": "/",
+  },
+  Object {
+    "children": "Skip to footer",
+    "className": "SkipLink-styles-module--skiplink--2HGNv",
+    "href": "#footer",
+  },
+  Object {
+    "children": "Skip to content",
+    "className": "SkipLink-styles-module--skiplink--2HGNv",
+    "href": "#main",
+  },
+  Object {},
+  Object {},
+  Object {},
+  Object {},
+  Object {
+    "children": "Responsive design glossary",
+    "href": "/responsive-design-glossary/",
+  },
+  Object {
+    "children": "Create Polypane workspace",
+    "href": "/create-workspace/",
+  },
+  Object {
+    "children": "Your screen size wall",
+    "href": "/responsive-website-test/",
+  },
+  Object {
+    "aria-current": "page",
+    "children": "CSS specificity calculator",
+    "className": "",
+    "href": "/css-specificity-calculator/",
+    "style": Object {},
+  },
+  Object {
+    "children": "Color contrast checker",
+    "href": "/color-contrast/",
+  },
+  Object {
+    "children": "Pricing",
+    "href": "/pricing/",
+  },
+  Object {
+    "children": "For QA",
+    "href": "/quality-assurance/",
+  },
+  Object {
+    "children": "For Agencies",
+    "href": "/agencies/",
+  },
+  Object {
+    "children": "For Marketers",
+    "href": "/marketers/",
+  },
+  Object {
+    "children": "All free tools",
+    "href": "/resources/",
+  },
+  Object {
+    "children": "Home",
+    "href": "/",
+  },
+  Object {
+    "children": "About",
+    "href": "/about/",
+  },
+  Object {
+    "children": "Blog",
+    "href": "/blog/",
+  },
+  Object {
+    "children": "Newsletter",
+    "href": "/newsletter/",
+  },
+  Object {
+    "children": "Accolades",
+    "href": "/accolades/",
+  },
+  Object {
+    "children": "Changelog",
+    "href": "/docs/changelog/",
+  },
+  Object {
+    "children": "Testimonials",
+    "href": "/testimonials/",
+  },
+  Object {
+    "children": "Download",
+    "href": "/download/",
+  },
+  Object {
+    "children": "Integrations",
+    "href": "/integrations/",
+  },
+  Object {
+    "children": "Docs",
+    "href": "/docs/",
+  },
+  Object {
+    "children": "Site Quality",
+    "href": "/site-quality/",
+  },
+  Object {
+    "children": "Accessibility",
+    "href": "/accessibility/",
+  },
+  Object {
+    "children": "Accessibility Statement",
+    "href": "/accessibility-statement/",
+  },
+  Object {
+    "children": "Disclaimer",
+    "href": "/disclaimer/",
+  },
+  Object {
+    "children": "Legal",
+    "href": "/legal/",
+  },
+  Object {
+    "children": Array [],
+    "className": "Releases-styles-module--fulllink--3XjeX",
+    "href": "/docs/changelog/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/blog/polypane-8-1-resizable-element-tree-disable-js-feature-new-debug-tools-and-more/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/blog/polypane-8-1-resizable-element-tree-disable-js-feature-new-debug-tools-and-more/",
+  },
+  Object {
+    "children": "Blog",
+    "href": "/blog/",
+  },
+  Object {
+    "children": "Testimonials",
+    "href": "/testimonials/",
+  },
+  Object {
+    "children": "Docs",
+    "href": "/docs/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/create-workspace/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/visualize-browser-sizes/",
+  },
+  Object {
+    "aria-current": "page",
+    "children": Array [],
+    "className": "",
+    "href": "/css-specificity-calculator/",
+    "style": Object {},
+  },
+  Object {
+    "children": Array [],
+    "href": "/color-contrast/",
+  },
+  Object {
+    "children": "Integrations",
+    "href": "/integrations/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/agencies/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/marketers/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/quality-assurance/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/site-quality/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/accessibility/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/blog/polypane-9-screenshot-editor-structured-data-support-and-new-debug-tools/",
+  },
+  Object {
+    "children": Array [],
+    "className": "CTA-styles-module--button--2bMFr",
+    "href": "https://dashboard.polypane.app/register/",
+  },
+  Object {
+    "children": Object {},
+    "className": "Header-styles-module--button--3nyub",
+    "href": "https://dashboard.polypane.app/register/",
+  },
+  Object {
+    "children": "Pricing",
+    "href": "/pricing/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/?ref=designers",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/?ref=developers",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/?ref=responsive-design",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/",
+  },
+  Object {
+    "activeStyle": Object {},
+    "children": "For Designers",
+    "href": "/product-tour/?ref=designers",
+  },
+  Object {
+    "activeStyle": Object {},
+    "children": "For Developers",
+    "href": "/product-tour/?ref=developers",
+  },
+  Object {
+    "children": "Manage Account",
+    "href": "https://dashboard.polypane.app/",
+  },
+  Object {
+    "children": "Support",
+    "href": "/support/",
+  },
+  Object {
+    "children": "privacy policy",
+    "href": "/privacy/",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/?ref=developers",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/?ref=responsive-design",
+  },
+  Object {
+    "children": Array [],
+    "href": "/product-tour/?ref=designers",
+  },
+  Object {
+    "children": "Privacy",
+    "href": "/privacy/",
+  },
+  Object {
+    "children": Object {},
+    "className": "Header-styles-module--button--3nyub",
+    "href": "https://dashboard.polypane.app/register/",
+  },
+  Object {
+    "href": "https://polypane.app/rss.xml",
+    "rel": "alternate",
+    "title": "Polypane Blog",
+    "type": "application/rss+xml",
+  },
+  Object {
+    "href": "https://chrome.google.com/webstore/detail/eofbapfmbfmpeplodnehlkkgpkklmapp",
+    "rel": "chrome-webstore-item",
+  },
+  Object {
+    "as": "font",
+    "crossOrigin": "anonymous",
+    "href": "/static/Inter-roman.var-subset-4205477ad91e63d6d092b4e155e529a2.woff2",
+    "rel": "preload",
+    "type": "font/woff2",
+  },
+  Object {
+    "as": "font",
+    "crossOrigin": "anonymous",
+    "href": "/static/Inter-italic.var-subset-b850defff6a5dd08ab5b60d16fd28a87.woff2",
+    "rel": "preload",
+    "type": "font/woff2",
+  },
+  Object {
+    "children": Array [],
+    "className": "CTA-styles-module--button--2bMFr",
+    "href": "https://dashboard.polypane.app/register/",
+  },
+  Object {
+    "href": "https://polypane.app/rss.xml",
+    "rel": "alternate",
+    "title": "Polypane Blog",
+    "type": "application/rss+xml",
+  },
+  Object {
+    "href": "https://chrome.google.com/webstore/detail/eofbapfmbfmpeplodnehlkkgpkklmapp",
+    "rel": "chrome-webstore-item",
+  },
+  Object {
+    "as": "font",
+    "crossOrigin": "anonymous",
+    "href": "/static/Inter-roman.var-subset-4205477ad91e63d6d092b4e155e529a2.woff2",
+    "rel": "preload",
+    "type": "font/woff2",
+  },
+  Object {
+    "as": "font",
+    "crossOrigin": "anonymous",
+    "href": "/static/Inter-italic.var-subset-b850defff6a5dd08ab5b60d16fd28a87.woff2",
+    "rel": "preload",
+    "type": "font/woff2",
+  },
+  Object {
+    "children": Array [],
+    "href": "https://twitter.com/intent/user?screen_name=polypane",
+  },
+  Object {
+    "children": Array [],
+    "href": "https://polypane-slack-invite.herokuapp.com/",
+  },
+  Object {
+    "activeStyle": Object {},
+    "children": "Responsive design",
+    "href": "/product-tour/?ref=responsive-design",
+  },
+  Object {
+    "activeStyle": Object {},
+    "children": "For Developers",
+    "href": "/product-tour/?ref=developers",
+  },
+  Object {
+    "children": "Manage Account",
+    "href": "https://dashboard.polypane.app/",
+  },
+  Object {
+    "activeStyle": Object {},
+    "children": "For Designers",
+    "href": "/product-tour/?ref=designers",
+  },
+  Object {
+    "activeStyle": Object {},
+    "children": "Responsive design",
+    "href": "/product-tour/?ref=responsive-design",
+  },
+  Object {
+    "children": Array [],
+    "href": "https://twitter.com/intent/user?screen_name=polypane",
+  },
+  Object {
+    "children": Array [],
+    "href": "https://polypane-slack-invite.herokuapp.com/",
+  },
+  Object {
+    "hash": "",
+    "host": "polypane.app",
+    "hostname": "polypane.app",
+    "href": "https://polypane.app/css-specificity-calculator/",
+    "key": "initial",
+    "origin": "https://polypane.app",
+    "pathname": "/css-specificity-calculator/",
+    "port": "",
+    "protocol": "https:",
+    "search": "",
+  },
+  Object {},
+]
+`;

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -52,6 +52,27 @@ describe("query", () => {
       `);
     });
 
+    it("finds some objects respecting unwantedNodeNames and maxDepth options", async () => {
+      const heapSnapshot = await readHeapSnapshot(
+        __dirname + "/fixtures/data/example-with-builtins.heapsnapshot"
+      );
+
+      expect(
+        findObjectsWithProperties(heapSnapshot, ["href"], {
+          unwantedNodeNames: [
+            "Location",
+            "HTMLAnchorElement",
+            "URL",
+            "HTMLLinkElement",
+            "SVGGradientElement",
+            "SVGFilterElement",
+          ],
+
+          maxDepth: 1,
+        })
+      ).toMatchSnapshot();
+    });
+
     it("finds some objects with more specific properties", async () => {
       expect(findObjectsWithProperties(heapSnapshot, ["bar", "boot"]))
         .toMatchInlineSnapshot(`
@@ -71,7 +92,7 @@ describe("query", () => {
       ).toMatchInlineSnapshot(`Array []`);
     });
 
-    it("ignores propertoes", async () => {
+    it("ignores properties", async () => {
       expect(
         findObjectsWithProperties(heapSnapshot, ["bar"], {
           ignoreProperties: ["foo"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "sourceMap": true,
     "moduleResolution": "node",
     "declaration": true,
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/types",
+    "strict": true
   },
   "include": ["src/**/*", "tests/**/*", "bin/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR brings following changes:

1. extends options object that can be passed to `query` (both from CLI and as direct dependency) with depth value (to have ability explicitly limit recursions) (CLI: `depth` / prop: `maxDepth`) and unwanted node names list^ (CLI: `exclude` /  prop: `unwantedNodeNames`);
2. enables stricter ts rules;
3. rest of little minor changes.

^ These changes can help to overcome situations like one that described in #1.

Example of usage: `npx puppeteer-heap-snapshot.js query -u https://polypane.app/css-specificity-calculator/ -p href -e Location,HTMLAnchorElement,URL,HTMLLinkElement,SVGGradientElement,SVGFilterElement -d 1`.